### PR TITLE
Add login/signup CTA on Home and dedicated auth pages

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -3,6 +3,8 @@ import {type RouteConfig, index, route} from "@react-router/dev/routes";
 export default [
     index("routes/home.tsx"),
     route('/auth', 'routes/auth.tsx'),
+    route('/login', 'routes/login.tsx'),
+    route('/signup', 'routes/signup.tsx'),
     route('/upload', 'routes/upload.tsx'),
     route('/resume/:id', 'routes/resume.tsx'),
     route('/wipe', 'routes/wipe.tsx'),

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -18,9 +18,7 @@ export default function Home() {
   const [resumes, setResumes] = useState<Resume[]>([]);
   const [loadingResumes, setLoadingResumes] = useState(false);
 
-  useEffect(() => {
-    if(!auth.isAuthenticated) navigate('/auth?next=/');
-  }, [auth.isAuthenticated])
+  // Keep Home accessible; show CTA instead of redirect when logged out
 
   useEffect(() => {
     const loadResumes = async () => {
@@ -56,6 +54,12 @@ export default function Home() {
             <h2>No resumes found. Upload your first resume to get feedback.</h2>
         ): (
           <h2>Review your submissions and check AI-powered feedback.</h2>
+        )}
+        {!auth.isAuthenticated && (
+          <div className="mt-6 flex gap-4 justify-center">
+            <Link to="/login?next=/" className="primary-button w-fit text-lg font-semibold">Log In</Link>
+            <Link to="/signup?next=/" className="primary-button w-fit text-lg font-semibold">Sign Up</Link>
+          </div>
         )}
       </div>
       {loadingResumes && (

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,0 +1,52 @@
+import { usePuterStore } from "~/lib/puter";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+export const meta = () => ([
+  { title: 'Resumind | Log In' },
+  { name: 'description', content: 'Log into your account' },
+])
+
+export default function Login() {
+  const { isLoading, auth } = usePuterStore();
+  const location = useLocation();
+  const next = new URLSearchParams(location.search).get('next') || '/';
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (auth.isAuthenticated) navigate(next);
+  }, [auth.isAuthenticated, next, navigate]);
+
+  const handleLogin = async () => {
+    setSubmitting(true);
+    await auth.signIn();
+    setSubmitting(false);
+  }
+
+  return (
+    <main className="bg-[url('/images/bg-auth.svg')] bg-cover min-h-screen flex items-center justify-center">
+      <div className="gradient-border shadow-lg">
+        <section className="flex flex-col gap-8 bg-white rounded-2xl p-10 w-[min(480px,92vw)]">
+          <div className="flex flex-col items-center gap-2 text-center">
+            <h1>Welcome Back</h1>
+            <h2>Sign in to continue</h2>
+          </div>
+          <form className="flex flex-col gap-4">
+            <div className="form-div">
+              <label htmlFor="email">Email</label>
+              <input type="email" id="email" placeholder="you@example.com" disabled />
+            </div>
+            <div className="form-div">
+              <label htmlFor="password">Password</label>
+              <input type="password" id="password" placeholder="••••••••" disabled />
+            </div>
+            <button type="button" onClick={handleLogin} className="auth-button" disabled={isLoading || submitting}>
+              <p>{(isLoading || submitting) ? 'Signing you in...' : 'Log In'}</p>
+            </button>
+          </form>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/app/routes/resume.tsx
+++ b/app/routes/resume.tsx
@@ -19,7 +19,7 @@ const Resume = () => {
     const navigate = useNavigate();
 
     useEffect(() => {
-        if (!isLoading && !auth.isAuthenticated) navigate(`/auth?next=/resume/${id}`);
+        if (!isLoading && !auth.isAuthenticated) navigate(`/login?next=/resume/${id}`);
     }, [isLoading, auth.isAuthenticated, id, navigate])
 
     useEffect(() => {

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,0 +1,57 @@
+import { usePuterStore } from "~/lib/puter";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+export const meta = () => ([
+  { title: 'Resumind | Sign Up' },
+  { name: 'description', content: 'Create an account' },
+])
+
+export default function Signup() {
+  const { isLoading, auth } = usePuterStore();
+  const location = useLocation();
+  const next = new URLSearchParams(location.search).get('next') || '/';
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (auth.isAuthenticated) navigate(next);
+  }, [auth.isAuthenticated, next, navigate]);
+
+  const handleSignup = async () => {
+    setSubmitting(true);
+    // Using the same signIn for Puter auth; would be signUp if available
+    await auth.signIn();
+    setSubmitting(false);
+  }
+
+  return (
+    <main className="bg-[url('/images/bg-auth.svg')] bg-cover min-h-screen flex items-center justify-center">
+      <div className="gradient-border shadow-lg">
+        <section className="flex flex-col gap-8 bg-white rounded-2xl p-10 w-[min(480px,92vw)]">
+          <div className="flex flex-col items-center gap-2 text-center">
+            <h1>Create Account</h1>
+            <h2>Join Resumind to get started</h2>
+          </div>
+          <form className="flex flex-col gap-4">
+            <div className="form-div">
+              <label htmlFor="name">Name</label>
+              <input type="text" id="name" placeholder="Jane Doe" disabled />
+            </div>
+            <div className="form-div">
+              <label htmlFor="email">Email</label>
+              <input type="email" id="email" placeholder="you@example.com" disabled />
+            </div>
+            <div className="form-div">
+              <label htmlFor="password">Password</label>
+              <input type="password" id="password" placeholder="••••••••" disabled />
+            </div>
+            <button type="button" onClick={handleSignup} className="auth-button" disabled={isLoading || submitting}>
+              <p>{(isLoading || submitting) ? 'Creating your account...' : 'Sign Up'}</p>
+            </button>
+          </form>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/app/routes/upload.tsx
+++ b/app/routes/upload.tsx
@@ -16,7 +16,7 @@ const Upload = () => {
 
     useEffect(() => {
         if (!isLoading && !auth.isAuthenticated) {
-            navigate('/auth?next=/upload');
+            navigate('/login?next=/upload');
         }
     }, [isLoading, auth.isAuthenticated, navigate]);
 
@@ -47,7 +47,7 @@ const Upload = () => {
         if (!userId) {
             setStatusText('Error: Not authenticated');
             setIsProcessing(false);
-            navigate('/auth?next=/upload');
+            navigate('/login?next=/upload');
             return;
         }
         const uuid = generateUUID();

--- a/app/routes/wipe.tsx
+++ b/app/routes/wipe.tsx
@@ -18,7 +18,7 @@ const WipeApp = () => {
 
     useEffect(() => {
         if (!isLoading && !auth.isAuthenticated) {
-            navigate("/auth?next=/wipe");
+            navigate("/login?next=/wipe");
         }
     }, [isLoading]);
 


### PR DESCRIPTION
- Home: show Log In / Sign Up buttons below heading when logged out
- New routes: /login and /signup with styled forms matching app theme
- Guards: redirect unauthenticated access to /login with next= param
- Keep navbar and backgrounds consistent across pages

Users cannot upload or view resumes until authenticated; after login/signup redirect to Home.